### PR TITLE
Add GitHub Actions workflow for automatic GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+      - id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow (`.github/workflows/deploy.yml`) that automatically deploys to GitHub Pages when changes are pushed to the `main` branch
- The workflow uses the official `actions/deploy-pages` action for reliable deployments
- Supports manual triggering via `workflow_dispatch`

## Test plan
- [ ] Merge this PR and verify the workflow runs successfully
- [ ] Confirm the site is deployed to GitHub Pages after the workflow completes
- [ ] Test manual trigger via the Actions tab

https://claude.ai/code/session_01CdNUz3f35bbscGQUBGuvs7