### PR TITLE
Fix gallery not showing photos (cache-busting)

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,7 +257,7 @@
     });
   }
 
-  fetch('photos.json')
+  fetch('photos.json?v=' + Date.now())
     .then(r => r.json())
     .then(renderGallery)
     .catch(() => renderGallery([]));


### PR DESCRIPTION
## Summary
- Adds a cache-busting timestamp to the `photos.json` fetch so browsers always load the latest manifest
- This fixes the gallery showing "no shots yet" even after photos were uploaded

https://claude.ai/code/session_01CdNUz3f35bbscGQUBGuvs7