### PR TITLE
Preserve original photo aspect ratios

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,10 +91,10 @@
 
     /* ── gallery ── */
     .gallery {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 28px;
-      justify-content: center;
+      column-width: 180px;
+      column-gap: 28px;
+      max-width: 960px;
+      margin: 0 auto;
     }
 
     /* ── card ── */
@@ -108,6 +108,10 @@
       transition: transform 0.18s ease, box-shadow 0.18s ease;
       opacity: 0;
       translate: 0 14px;
+      break-inside: avoid;
+      margin-bottom: 28px;
+      display: inline-block;
+      width: 100%;
     }
 
     .card.visible {
@@ -140,9 +144,8 @@
     /* photo */
     .card img {
       display: block;
-      width: 160px;
-      height: 120px;
-      object-fit: cover;
+      width: 100%;
+      height: auto;
       background: #ddd;
     }
 
@@ -154,7 +157,7 @@
       margin-top: 8px;
       opacity: 0.5;
       text-align: center;
-      max-width: 160px;
+      max-width: 100%;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
@@ -183,12 +186,7 @@
 
     /* ── mobile ── */
     @media (max-width: 520px) {
-      .card img {
-        width: 120px;
-        height: 90px;
-      }
-      .caption { max-width: 120px; }
-      .gallery { gap: 18px; }
+      .gallery { column-gap: 18px; }
       header h1 { font-size: 2.4rem; }
     }
   </style>


### PR DESCRIPTION
Switch from fixed 160x120 cropped thumbnails to auto-height images with CSS columns masonry layout.

https://claude.ai/code/session_01CdNUz3f35bbscGQUBGuvs7