### PR TITLE
Left-align titles, unbold, rename title bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>tiny shots</title>
+  <title>shots shots shots</title>
   <style>
     /* ── reset ── */
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
@@ -157,9 +157,9 @@
     .card-title {
       font-size: 0.85rem;
       color: #000;
-      font-weight: 700;
+      font-weight: normal;
       margin-bottom: 6px;
-      text-align: center;
+      text-align: left;
       font-family: 'Courier New', monospace;
     }
 
@@ -226,7 +226,7 @@
 <div class="window">
   <div class="title-bar">
     <div class="close-box"></div>
-    <span class="title-bar-text">tiny shots</span>
+    <span class="title-bar-text">shots shots shots</span>
   </div>
   <div class="window-body">
 


### PR DESCRIPTION
Titles left-aligned and normal weight. Page and title bar now say shots shots shots.